### PR TITLE
Added a way to increase the number of visible tracks

### DIFF
--- a/components/PacketVisualization/PacketVisualization.css
+++ b/components/PacketVisualization/PacketVisualization.css
@@ -18,14 +18,72 @@
     border: 1px solid var(--card-border-color);
 }
 
+.card-header{
+    padding: 1rem;
+    padding-left: clamp(5px, 5vw, 1.8rem);
+    box-sizing: border-box;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: .6rem;
+    border-bottom: 1px solid var(--card-border-color);
+}
+
 h2{
     font-size: 2rem;
     color: var(--text-color);
     display: flex;
     align-items: center;
-    padding: 1rem;
-    padding-left: 1.8rem;
-    border-bottom: 1px solid var(--card-border-color);
+}
+
+.card-header menu{
+    display: flex;
+}
+
+button{
+    outline: none;
+    cursor: pointer;
+}
+
+.btn{
+    background-color: var(--primary-button-color);
+    color: var(--primary-button-text-color);
+    font-size: 1rem;
+    padding: 0.5em 1em;
+    border-radius: 0.3em;
+    transition: box-shadow .15s,
+        background-color .2s;
+}
+
+.btn i{
+    margin-right: 0.5em;
+    font-size: 1em;
+}  
+
+.btn:focus{
+    box-shadow: 0 0 0 .25em var(--primary-button-border-color);
+}
+
+.btn:hover{
+    background-color: var(--primary-button-hover-color);
+}
+
+.btn:disabled{
+    background-color: var(--primary-button-disabled-color);
+    cursor: default;
+}
+
+#expand-tracks-btn span{
+    display: none;
+    align-items: center;
+}
+
+#expand-tracks-btn:not(.expanded) .show-more{
+    display: inline-flex;
+}
+
+#expand-tracks-btn.expanded .show-less{
+    display: inline-flex;
 }
 
 #visualization-content{
@@ -40,6 +98,11 @@ svg{
     box-sizing: border-box;
 }
 
+svg.expanded{
+    flex-basis: 100%;
+    padding-bottom: 0px;
+}
+
 svg .background{
     fill: #f2f2f2;
     rx: 20px;
@@ -47,11 +110,6 @@ svg .background{
 }
 
 @media(max-width: 600px){
-    h2{
-        padding-left: 1rem;
-        justify-content: center;
-    }
-
     svg{
         padding: 0;
         margin-bottom: .8rem;

--- a/components/PacketVisualization/PacketVisualization.js
+++ b/components/PacketVisualization/PacketVisualization.js
@@ -12,6 +12,13 @@ export default class PacketVisualization extends HTMLElement {
         this.senderWindow = this.shadowRoot.querySelector("#sender-window");
         this.receiverWindow = this.shadowRoot.querySelector("#receiver-window");
         this.tracks = this.shadowRoot.querySelector("#tracks");
+        this.expandTracksBtn = this.shadowRoot.querySelector("#expand-tracks-btn");
+        this.rootSvg = this.shadowRoot.querySelector("#root-svg");
+        this.senderTag = this.shadowRoot.querySelector("#sender-tag");
+        this.receiverTag = this.shadowRoot.querySelector("#receiver-tag");
+        this.isExpanded = false;
+        this.returnLimit = 800;
+        this.expandTracksBtn.onclick = () => this._toggleExpandTracks();
         this._init();
     }
 
@@ -29,7 +36,7 @@ export default class PacketVisualization extends HTMLElement {
         this.senderWindow.style.display = "none";
         this.receiverWindow.style.display = "none";
         // Put double the number of visible tracks
-        for(let i=0; i< 32; i++){
+        for(let i=0; i< 96; i++){
             let trackContainer;
             if(reset){
                 // Reset track containers
@@ -71,7 +78,7 @@ export default class PacketVisualization extends HTMLElement {
     move(spaces){
         if(spaces === 0)
             return;
-        const transition= `x ${spaces * 50}ms linear`;
+        const transition= `x ${spaces * 25}ms linear`;
         let lastChildX = Number.parseInt(this.tracks.lastElementChild.getAttribute("x"));
         // Make a copy, as we may modify children positions
         const children = Array.from(this.tracks.children);
@@ -164,11 +171,11 @@ export default class PacketVisualization extends HTMLElement {
             trackContainer.seqNum = seqNum;
             if (this.protocol === 1){
                 const nexContainerPosition = Number.parseInt(this.nextTrackContainer.getAttribute("x"));
-                if(nexContainerPosition >= 1500)
+                if(nexContainerPosition >= this.returnLimit)
                     this.move(nexContainerPosition / 100 - 2);
             }else{
                 const windowPosition = Number.parseInt(this.senderWindow.getAttribute("x"));
-                if((windowPosition + this.windowSize * 100) >= 1500)
+                if(windowPosition >= this.returnLimit)
                     this.move(windowPosition / 100 - 1);
             }
         }
@@ -184,7 +191,7 @@ export default class PacketVisualization extends HTMLElement {
     moveWindow(spaces, moveReceiver=false){
         if(spaces === 0)
             return;
-        const transitionTime = Math.abs(spaces) * 50;
+        const transitionTime = Math.abs(spaces) * 25;
         const window = moveReceiver ? this.receiverWindow : this.senderWindow;
         window.style.transition = `x ${transitionTime}ms linear`;
         const x = Number.parseInt(window.getAttribute("x"));
@@ -290,5 +297,29 @@ export default class PacketVisualization extends HTMLElement {
     resume(){
         for(const container of this.tracks.children)
             container.firstElementChild.resume();
+    }
+
+    /**
+     * Show or hide additional tracks of the visualization.
+     * @private
+     */
+    _toggleExpandTracks(){
+        if(this.isExpanded){
+            this.rootSvg.setAttribute("viewBox", "0 0 1600 900");
+            this.rootSvg.classList.remove("expanded");
+            this.senderTag.setAttribute("x", 540);
+            this.receiverTag.setAttribute("x", 480);
+            this.expandTracksBtn.classList.remove("expanded");
+            this.returnLimit = 800;
+            this.isExpanded = false;
+        }else{
+            this.rootSvg.setAttribute("viewBox", "0 0 4200 900");
+            this.rootSvg.classList.add("expanded");
+            this.senderTag.setAttribute("x", 1940);
+            this.receiverTag.setAttribute("x", 1880); 
+            this.expandTracksBtn.classList.add("expanded");
+            this.returnLimit = 2100;
+            this.isExpanded = true;
+        }
     }
 }

--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
                     </label>
                     <label>
                         <span class="label-text">Window size</span>
-                        <input name="windowSize" type="range" step="1" min="1" max="10" value="1">
+                        <input name="windowSize" type="range" step="1" min="1" max="40" value="1">
                         <p>1</p>
                         <small>
                             The size of the window for GBN and SR.
@@ -152,10 +152,26 @@
 
     <template id="packet-visualization">
         <link rel="stylesheet" href="./components/PacketVisualization/PacketVisualization.css">
+        <link rel="stylesheet" href="./fontawesome/css/all.css">
         <section class="card">
+            <div class="card-header">
             <h2>Visualization</h2>
+                <menu class="top-menu">
+                    <button id="expand-tracks-btn" type="button" class="btn">
+                        <span class="show-more">
+                            <i class="fas fa-plus-square"></i>
+                            Show more tracks
+                        </span>
+                        <span class="show-less">
+                            <i class="fas fa-minus-square"></i>
+                            Show less tracks
+                        </span>
+                    </button>
+                </menu>
+            </div>
+            
             <div id="visualization-content">
-                <svg viewBox="0 0 1600 900">
+                <svg id="root-svg" viewBox="0 0 1600 900">
                     <rect class="background" width="100%" height="100%"/>
                     <text x="540" y="250" id="sender-tag" class="node-tag">SENDER</text>
                     <text x="480" y="735" id="receiver-tag" class="node-tag">RECEIVER</text>


### PR DESCRIPTION
Added a button in the visualization card header that allows to
show or hide additional tracks for the visualization.
Increased the upper limit for the size of the sliding window
to 40 in the settings card component.
Resolves #43.