### PR TITLE
Centered the tags of the visualization for Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,8 +174,8 @@
                 <figure id="visualization-figure">
                    <svg id="root-svg" viewBox="0 0 1600 900">
                         <rect id="background-svg" width="100%" height="100%"/>
-                        <text y="250" id="sender-tag" class="node-tag">SENDER</text>
-                        <text y="735" id="receiver-tag" class="node-tag">RECEIVER</text>
+                        <text x="539.5454711914062" y="250" id="sender-tag" class="node-tag">SENDER</text>
+                        <text x="480.492431640625" y="735" id="receiver-tag" class="node-tag">RECEIVER</text>
                         <foreignObject id="sliding-view" width="100%" height="100%" x="0" y="0" >
                             <svg id="sliding-view-content" viewBox="0 0 1600 900">
                                 <rect id="sender-window" x="100" y="14" width="400" height="124"/>


### PR DESCRIPTION
For some reason the onload event of the SVG of the visualization
is not firing in Firefox, so to fix the initial centering of the
labels I added the x attribute to both tags in the HTML.